### PR TITLE
Fix an error in the example debugging command in `debugging.md`

### DIFF
--- a/getting-started/debug-and-test/debugging.md
+++ b/getting-started/debug-and-test/debugging.md
@@ -280,7 +280,7 @@ We also provide a set of macros specialized for debugging Pintos, written by God
   * Attach debugger to a waiting pintos process on the same machine. Shorthand for `target remote localhost:1234`.
 * <mark style="color:blue;">**GDB Macro: dumplist &**</mark>_<mark style="color:blue;">**list type element**</mark>_
   * Prints the elements of _list_, which should be a `struct` _list_ that contains elements of the given _type_ (without the word `struct`) in which _element_ is the `struct list_elem` member that links the elements.
-  * Example: `dumplist all_list thread allelem` prints all elements of `struct thread` that are linked in `struct list all_list` using the `struct list_elem allelem` which is part of `struct thread`.
+  * Example: `dumplist &all_list thread allelem` prints all elements of `struct thread` that are linked in `struct list all_list` using the `struct list_elem allelem` which is part of `struct thread`.
 * <mark style="color:blue;">**GDB Macro:**</mark> <mark style="color:blue;">**btthread**</mark> <mark style="color:blue;"></mark><mark style="color:blue;"></mark> <mark style="color:blue;"></mark>_<mark style="color:blue;">**thread**</mark>_
   * Shows the backtrace of _thread_, which is a pointer to the `struct thread` of the thread whose backtrace it should show. For the current thread, this is identical to the `bt` (backtrace) command. It also works for any thread suspended in `schedule()`, provided you know where its kernel stack page is located.
 * <mark style="color:blue;">**GDB Macro:**</mark> <mark style="color:blue;">**btthreadlist**</mark> _<mark style="color:blue;">**list element**</mark>_


### PR DESCRIPTION
Change `dumplist all_list thread allelem` to `dumplist &all_list thread allelem`.

If we execute the former one, GDB will give us a warning: "Attempt to take address of value not located in memory.".

If we execute the latter one, the list will be printed correctly.