### PR TITLE
[Fix] remove one sentence in `suggestions.md` for lab2

### DIFF
--- a/project-description/lab2-user-programs/suggestions.md
+++ b/project-description/lab2-user-programs/suggestions.md
@@ -4,7 +4,7 @@
 
 We suggest first implementing the following, which can happen in parallel:
 
-* **Argument passing.** Every user program will page fault immediately until argument passing is implemented. If you implement it correctly, you should pass all the `args-xxx` test cases.
+* **Argument passing.** Every user program will page fault immediately until argument passing is implemented.
 * **`halt` system call.** This is the easiest system call to implement, but it is a big step to have a working system call infrastructure. You should implement enough code to read the system call number from the user stack and dispatch it to a handler based on it.
 * **The `exit` system call.** Every user program that finishes in the normal way calls `exit`. Even a program that returns from `main()` calls `exit` indirectly (see `_start()` in `lib/user/entry.c`).
 * **The `write` system call for writing to fd 1, the system console.** <mark style="color:red;">**All of our test programs write to the console**</mark> (the user process version of `printf()` is implemented this way), so they will all malfunction until `write` is available.


### PR DESCRIPTION
Remove the sentence "you should pass all the `args-xxx` test cases" in `project-description/lab2-user-programs/suggestions.md`.

We won't pass the `arg-xxx` testcases after implementing argument passing, because the C program used in these testcases, `args.c`, need to use `write` and `exit` syscalls. If we do not implement those syscalls, the kernel will simply print out "Syscall!" and terminate the process.

Note: We cannot pass the `arg-xxx` testcases even after implementing all the things mentioned in `suggestion.md`, because just changing `process_wait()` to an infinite loop will lead to a timeout when running `make check`.